### PR TITLE
Ubuntu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Required variables
 | proxmox_vm_storage | local | the storage that the VM is cloned onto
 | proxmox_bootstrap_user | bootstrap | the name of the user that is added to the VM
 | proxmox_bootstrap_sshkey | random | the ssh key of the bootstrap user. if this is "random", a new key will be created for the first connection
-| debian_template_vmid | | the id of the template to be cloned, usually set by the proxmox_debian_cloudimage role
+| linux_template_vmid | | the id of the template to be cloned, usually set by the proxmox_linux_cloudimage role
 
 Optional variables
 | variable | default value | description/alternatives
@@ -35,19 +35,19 @@ If the optional variables are not defined, then no change is made to the VM and 
 Example Playbook
 ----------------
 
-Here's an example including the [h3po.proxmox_debian_cloudimage](https://github.com/h3po/ansible-role-proxmox-debian-cloudimage/) role to create the template and then clone it to 'new-debian-vm'. The detection of wether the VM already exists or not depends on the variable `proxmox_vmid` set by the proxmox inventory plugin from the [community.general](https://github.com/ansible-collections/community.general) collection.
+Here's an example including the [h3po.proxmox_linux_cloudimage](https://github.com/h3po/ansible-role-proxmox-linux-cloudimage/) role to create the template and then clone it to 'new-linux-vm'. The detection of wether the VM already exists or not depends on the variable `proxmox_vmid` set by the proxmox inventory plugin from the [community.general](https://github.com/ansible-collections/community.general) collection.
 
 ```yaml
 ---
-- name: create a debian vm
-  hosts: new-debian-vm
+- name: create a linux vm
+  hosts: new-linux-vm
   become: true
   gather_facts: false
   vars:
     proxmox_template_pool: template
-    debian_cloudimage_repo_subdir: bullseye
-    debian_cloudimage_keep: true
-    debian_cloudimage_qemuagent: true
+    linux_cloudimage_repo_subdir: bullseye
+    linux_cloudimage_keep: true
+    linux_cloudimage_qemuagent: true
     proxmox_bootstrap_user: test
     proxmox_bootstrap_sshkey: ssh-ed25519 AAAAxyzkkMN test
   tasks:
@@ -63,7 +63,7 @@ Here's an example including the [h3po.proxmox_debian_cloudimage](https://github.
           delegate_to: sc721.home.h3po.de
           become: true
 
-        - name: create the debian template
+        - name: create the linux template
           import_role:
             name: h3po.proxmox_debian_cloudimage
           delegate_to: sc721.home.h3po.de

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Required variables
 | proxmox_vm_storage | local | the storage that the VM is cloned onto
 | proxmox_bootstrap_user | bootstrap | the name of the user that is added to the VM
 | proxmox_bootstrap_sshkey | random | the ssh key of the bootstrap user. if this is "random", a new key will be created for the first connection
-| linux_template_vmid | | the id of the template to be cloned, usually set by the proxmox_linux_cloudimage role
+| linux_template_vmid | | the id of the template to be cloned, usually set by the proxmox_debian_cloudimage role
 
 Optional variables
 | variable | default value | description/alternatives
@@ -35,7 +35,7 @@ If the optional variables are not defined, then no change is made to the VM and 
 Example Playbook
 ----------------
 
-Here's an example including the [h3po.proxmox_linux_cloudimage](https://github.com/h3po/ansible-role-proxmox-linux-cloudimage/) role to create the template and then clone it to 'new-linux-vm'. The detection of wether the VM already exists or not depends on the variable `proxmox_vmid` set by the proxmox inventory plugin from the [community.general](https://github.com/ansible-collections/community.general) collection.
+Here's an example including the [h3po.proxmox_debian_cloudimage](https://github.com/h3po/ansible-role-proxmox-debian-cloudimage/) role to create the template and then clone it to 'new-linux-vm'. The detection of wether the VM already exists or not depends on the variable `proxmox_vmid` set by the proxmox inventory plugin from the [community.general](https://github.com/ansible-collections/community.general) collection.
 
 ```yaml
 ---

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,9 @@ galaxy_info:
     - name: Debian
       versions:
         - all
+    - name: Ubuntu
+      versions:
+        - all
 
   galaxy_tags:
     - proxmox

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   register: nextid
 
 - name: clone the template
-  ansible.builtin.command: qm clone {{ debian_template_vmid }} {{ nextid.stdout }} -full -storage {{ proxmox_vm_storage }} -name {{ inventory_hostname }} {{ '-pool %s' % proxmox_vm_pool if proxmox_vm_pool is defined}}
+  ansible.builtin.command: qm clone {{ linux_template_vmid }} {{ nextid.stdout }} -full -storage {{ proxmox_vm_storage }} -name {{ inventory_hostname }} {{ '-pool %s' % proxmox_vm_pool if proxmox_vm_pool is defined}}
   changed_when: true
   register: qmclone
 
@@ -86,7 +86,7 @@
   until: >-
     (
       (
-        (qmguestcmd.stdout or "[]") | from_json | selectattr('name', 'equalto', 'ens18') | first | default({})
+        (qmguestcmd.stdout or "[]") | from_json | rejectattr('name', 'equalto', 'lo') | first | default({})
       ).get('ip-addresses', []) | selectattr('ip-address-type', 'equalto', 'ipv4') | first | default({})
     ).get('ip-address', "") != ""
 
@@ -110,7 +110,7 @@
       {{
         (
           (
-            qmguestcmd.stdout | from_json | selectattr('name', 'equalto', 'ens18') | first
+            qmguestcmd.stdout | from_json | rejectattr('name', 'equalto', 'lo') | first
           ).get('ip-addresses') | selectattr('ip-address-type', 'equalto', 'ipv4') | first
         ).get('ip-address')
       }}


### PR DESCRIPTION
README.md
changed variable names according to h3po.proxmox_debian_cloudimage

tasks/main.yml
Changed selectattr('name', 'equalto', 'ens18') to rejectattr('name', 'equalto', 'lo') to get the ip address of the first network device.
According to Proxmox:
https://pve.proxmox.com/wiki/Cloud-Init_FAQ
For legacy reasons the network device names of cloud images are required to use the "old" network device names: (eth0, eth1, ...)[...]The newer nocloud v2 config format will be supported in the future, where this requirement is lifted. 
